### PR TITLE
Fixed building linux standalone apps

### DIFF
--- a/electron/build.js
+++ b/electron/build.js
@@ -78,8 +78,8 @@ async function build(platform, type){
 			}
 			fs.remove(buildDir)
 		} else if (platform == 'linux') {
-			await fs.remove(outDir)
-			await fs.move(buildDir, outDir, {overwrite: true});
+			await fs.remove(outputDir)
+			await fs.move(buildDir, outputDir, {overwrite: true});
 		} else {
 			await moveFiles(buildDir, outputDir)
 		}


### PR DESCRIPTION
* Fixed undefined variable in "linux-standalone" hook in `build.js` script, probably caused by incomplete refactoring of variable name