### PR TITLE
Update the building instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,29 @@ npm install
 
 ## Building
 
-The modules come as both standalone apps and Ableton integrated (currently this only builds for macOS). To build both versions run:
+The modules come as both standalone apps and Ableton integrated. To build all versions (Linux standalone and Mac, Windows in standalone and Max For Live formats) run:
 
 ```
 npm run build
 ```
 
 All of the build files will be put into the 'dist' folder.
+
+You can also build a specific target by passing it as an argument:
+
+```
+npm run build macos-standlone
+```
+
+The current options are:
+
+* windows-ableton
+* windows-standalone
+* linux-standalone
+* macos-ableton
+* macos-standalone
+
+*Note:* if you want to build Windows versions from Mac, you need to have [Wine](https://www.winehq.org/) installed.
 
 ## License
 


### PR DESCRIPTION
The build command has evolved since the README was written, this PR provides covers the new options and clarify the need for Wine to cross compile from Mac targeting Windows.